### PR TITLE
number of octaves can be chosen

### DIFF
--- a/src/DataSounds/sounds.py
+++ b/src/DataSounds/sounds.py
@@ -189,7 +189,9 @@ def get_music(series, key='C', mode='major', octaves=2,
         'major', 'minor' and 'pentatonic' are accetable parameters.
         More options of modes on `build_scale`.
 
-    octaves : Number of available scales for musical construction.
+    octaves : Number of octaves, or list of octaves (just in case you
+        will use more than one series and want to change their specific
+        number of octaves).
         As higher are the octaves higher pitch differeneces will occur
         while representing your data.
 
@@ -421,9 +423,10 @@ def get_music(series, key='C', mode='major', octaves=2,
     midi_out = BytesIO()
 
     series = np.array(series)
-    scale = build_scale(key, mode, octaves)
+    scales = []
     melodies = []
     if len(series.shape) == 1:
+        scale = build_scale(key, mode, octaves)
         if all(np.isnan(series)):
             melody = []
             melodies.append(melody)
@@ -437,8 +440,13 @@ def get_music(series, key='C', mode='major', octaves=2,
                 melody = []
                 melodies.append(melody)
             else:
-                snotes = note_number(series[i], scale)
-                melody = parse(' '.join([note_name(x, scale) for x in snotes]))
+                if isinstance(octaves, int):
+                    scales.append(build_scale(key, mode, octaves))
+                else:
+                    scales.append(build_scale(key, mode, octaves[i]))
+
+                snotes = note_number(series[i], scales[i])
+                melody = parse(' '.join([note_name(x, scales[i]) for x in snotes]))
                 melodies.append(melody)
 
             # chords = chord_scaled(series, scale, period)


### PR DESCRIPTION
by default, octaves is setted = 2, but When you have more than one series, it is possible to set different number of octaves for each serie. So it is now possible to use: octaves=(2,3) or octaves=(3,1) or simply octaves=2, which will use 2 octaves for each serie. See example:

    # Example
    ts_a = np.random.rand(8)
    ts_b = np.random.rand(8)
    mus = get_music([ts_a, ts_b], key="D", instruments=(0,23), octaves=(2,3))

closes #1 
